### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,14 +6,14 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RotaryEncoder	 KEYWORD1
+RotaryEncoder	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update	 KEYWORD2
-read	 KEYWORD2
+update	KEYWORD2
+read	KEYWORD2
 reset KEYWORD2
 
 #######################################

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ RotaryEncoder	KEYWORD1
 
 update	KEYWORD2
 read	KEYWORD2
-reset KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
- Remove leading space from keywords.txt identifier tokens.
- Use correct field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords